### PR TITLE
Fix to route to 'web' on port 80

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,10 +30,10 @@ http {
             proxy_pass http://edge:8080;
         }
         location / {
-            proxy_pass http://web:8080;
+            proxy_pass http://web:80;
         }
         location /__webpack_hmr {
-            proxy_pass http://web:8080/__webpack_hmr;
+            proxy_pass http://web:80/__webpack_hmr;
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             chunked_transfer_encoding off;


### PR DESCRIPTION
For dev, the `web` service is listening on port 80, not 8080.